### PR TITLE
Add setting config that might remove the weird mail errors

### DIFF
--- a/chemie/chemie/settings/base.py
+++ b/chemie/chemie/settings/base.py
@@ -467,3 +467,5 @@ CART_SESSION_ID = "cart"
 
 # Value used for Django's built-in messages framework
 MESSAGE_TAGS = {message_constants.ERROR: "danger"}
+
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')


### PR DESCRIPTION
Fix as suggested in [this thing](https://serverfault.com/questions/1050068/invalid-http-host-header-the-domain-name-provided-is-not-valid-according-to-rfc)